### PR TITLE
Replace genesis submodule branch to devel

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "genesis"]
 	path = genesis
-	url = https://github.com/antimatter-dao/bas-genesis-config
+	url = https://github.com/antimatter-dao/bas-genesis-config.git
+	branch = devel


### PR DESCRIPTION
The devel branch is evolving, and it is better to switch to the genesis repo default branch to `devel`.
@matterfun 